### PR TITLE
error de escritura en la vista _form de contact country->country_id

### DIFF
--- a/views/contact/_form.php
+++ b/views/contact/_form.php
@@ -61,7 +61,7 @@ $form = ActiveForm::begin();
                 <div class="col-lg-2"><?= $form->field($model, 'city')->textInput(['maxlength' => true]) ?></div>
 
                 <div class="col-lg-2">
-                    <?= $form->field($model, 'country')->widget(Select2::classname(), [
+                    <?= $form->field($model, 'country_id')->widget(Select2::classname(), [
                         'data' => UCatalogo::listCountries(),
                         'language' => 'es',
                         'options' => ['placeholder' => '...'],


### PR DESCRIPTION
al momento de seleccionar un registro de la tabla de contact para actualizar sus datos no reconocia el campo country debido a que ya no existe el campo en el modelo de igual manera pasaba la creacion de nuevos registros.