### PR TITLE
Correccion en url graphic/dashboard colorear mapa por region

### DIFF
--- a/web/js/script/dashboard_index.js
+++ b/web/js/script/dashboard_index.js
@@ -685,8 +685,8 @@
                     showInLegend: false,
                     joinBy: ['name', 'id'],
                     keys: [
-                        'name', 'total', 'mujeres', 'hombres',
-                        'lat', 'lon', 'pais', 'id', 'eventos'
+                        'id', 'total', 'mujeres', 'hombres',
+                        'lat', 'lon', 'pais', 'country'
                     ],
                     tooltip: {
                         headerFormat: '',


### PR DESCRIPTION
Se corrigio url graphic/dashboard colorear mapa por region

Archivo modificado dashboard_index.js
Se reemplazo key de la serie pertenecientes a Highcharts.mapChart. Linea 688 y 689 en el js

Key modificadas
se reemplazo 
"name" por "id"
"id" por "pais"
y se elimino la key "eventos"

ya que la consulta retorna solo ocho datos, el noveno(eventos) no existe.

[paisArray] => Array
        (
            [0] => Array
                (
                    [0] => Canada
                    [1] => 1
                    [2] => 0
                    [3] => 1
                    [4] => 60.1087
                    [5] => -113.643
                    [6] => Canadá
                    [7] => canadá
                )
)

Segun la documentacion de highcharts se requiere un identificador id: string dentro de las keys, 
por esta razon se le pasa como primer parametro 
https://api.highcharts.com/highmaps/series.map.data.id