### PR TITLE
Error en el CRUD de data_list que a su vez afectaban el CRUD de items relacionados

### DIFF
--- a/controllers/DataListController.php
+++ b/controllers/DataListController.php
@@ -60,8 +60,9 @@ class DataListController extends Controller
     public function actionView($id)
     {
         $model = $this->findModel($id);
-        if ($model->list_id)
-            $this->redirect(['view', 'id' => $model->list_id]);
+//        var_dump($model);
+        if ($model->data_list_id)
+            $this->redirect(['view', 'id' => $model->data_list_id]);
 
         return $this->render('view', [
             'model' => $model,
@@ -172,7 +173,7 @@ class DataListController extends Controller
     public function actionDelete($id)
     {
         $model = $this->findModel($id);
-        $padre = (int)$model->list_id;
+        $padre = (int)$model->data_list_id;
         $contactsCount = Contact::find()
             ->orWhere([
                 'and',
@@ -203,7 +204,7 @@ class DataListController extends Controller
         $request = Yii::$app->getRequest();
         $response = Yii::$app->response;
         if ($request->isPost && $model->load($request->post())) {
-            $model->list_id = $id;
+            $model->data_list_id = $id;
             $response->format = Response::FORMAT_JSON;
             $model->validate();
             return ['success' => $model->save(), 'errors' => $model->getFirstErrors()];

--- a/controllers/DataListController.php
+++ b/controllers/DataListController.php
@@ -60,7 +60,7 @@ class DataListController extends Controller
     public function actionView($id)
     {
         $model = $this->findModel($id);
-//        var_dump($model);
+
         if ($model->data_list_id)
             $this->redirect(['view', 'id' => $model->data_list_id]);
 

--- a/controllers/DataListController.php
+++ b/controllers/DataListController.php
@@ -101,12 +101,12 @@ class DataListController extends Controller
         $contacts = Contact::find()
             ->orWhere([
                 'and',
-                ['!=', 'education_id', ''],
+                ['!=', 'education_id', null],
                 ['education_id' => $id],
             ])
             ->orWhere([
                 'and',
-                ['!=', 'type_id', ''],
+                ['!=', 'type_id', null],
                 ['type_id' => $id],
             ])
             ->orWhere([
@@ -218,11 +218,11 @@ class DataListController extends Controller
     public function actionUpdateDetail($id)
     {
         $model = $this->findModel($id);
-        $list_id = $model->list_id;
+        $list_id = $model->data_list_id;
         $request = Yii::$app->getRequest();
         $response = Yii::$app->response;
         if ($request->isPost && $model->load($request->post())) {
-            $model->list_id = $list_id;
+            $model->data_list_id = $list_id;
             $response->format = Response::FORMAT_JSON;
             $model->validate();
             return ['success' => $model->save(), 'errors' => $model->getFirstErrors()];

--- a/views/data-list/view.php
+++ b/views/data-list/view.php
@@ -42,7 +42,7 @@ echo $this->render('_navbar', [
     <?= $this->render('_view', ['model' => $model, 'attrib' => 'name', 'class' => 'col-lg-3']) ?>
     <?= $this->render('_view', ['model' => $model, 'attrib' => 'slug', 'class' => 'col-lg-2']) ?>
     <?= $this->render('_view', ['model' => $model, 'attrib' => 'value', 'class' => 'col-lg-2']) ?>
-    <?= $this->render('_view', ['model' => $model, 'attrib' => 'list_id', 'class' => 'col-lg-2']) ?>
+    <?= $this->render('_view', ['model' => $model, 'attrib' => 'data_list_id', 'class' => 'col-lg-2']) ?>
     <?= $this->render('_view', ['model' => $model, 'attrib' => 'tag', 'class' => 'col-lg-2']) ?>
 </div>
 <div class="row">


### PR DESCRIPTION
Se corrigió el nombramiento del campo en los metodos de data_list en DatalistController campo (list_id x data_list_id), probando el proceso de creacion de un catalogo encontramos que debido a los cambios en la bd una vez que se ha creado un item para un catalogo y deseas ver detalles del nuevo item los where que se encuentran actionViewContacts esperaban un valor null o integer y se pasaba por defecto un string vacio generando problemas de extracion de datos relacionados a un item