### PR TITLE
correccion para actualizar/insertar un evento

### DIFF
--- a/models/Event.php
+++ b/models/Event.php
@@ -3,6 +3,7 @@
 namespace app\models;
 
 use Throwable;
+use app\components\UCatalogo;
 use Yii;
 use yii\db\ActiveQuery;
 use yii\db\Exception;
@@ -100,8 +101,9 @@ class Event extends base\Event
 
     public function getCountryName()
     {
-        if ($this->country_id)
-            return $this->country_id;
+        $countries = UCatalogo::listCountries();
+        if ($this->country_id && isset($countries[$this->country_id]))
+            return $countries[$this->country_id];
         return '';
     }
 

--- a/models/base/Event.php
+++ b/models/base/Event.php
@@ -44,13 +44,13 @@ abstract class Event extends ActiveRecord
     public function rules()
     {
         return [
-            [['structure_id', 'implementing_organization_id', 'country_id'], 'integer'],
+            [['structure_id', 'implementing_organization_id'], 'integer'],
             [['name', 'implementing_organization_id'], 'required'],
-            [['title', 'text', 'notes'], 'string'],
+            [['title', 'text', 'notes', 'country_id'], 'string'],
             [['start', 'end'], 'safe'],
             [['name'], 'string', 'max' => 455],
             [['organizer', 'place'], 'string', 'max' => 200],
-            [['country_id'], 'exist', 'skipOnError' => true, 'targetClass' => DataList::className(), 'targetAttribute' => ['country_id' => 'id']],
+            [['country_id'], 'exist', 'skipOnError' => true, 'targetClass' => DataList::className(), 'targetAttribute' => ['country_id' => 'value']],
             [['implementing_organization_id'], 'exist', 'skipOnError' => true, 'targetClass' => Organization::className(), 'targetAttribute' => ['implementing_organization_id' => 'id']],
             [['structure_id'], 'exist', 'skipOnError' => true, 'targetClass' => Structure::className(), 'targetAttribute' => ['structure_id' => 'id']],
         ];
@@ -90,7 +90,7 @@ abstract class Event extends ActiveRecord
      */
     public function getCountry()
     {
-        return $this->hasOne(\app\models\DataList::className(), ['id' => 'country_id']);
+        return $this->hasOne(\app\models\DataList::className(), ['value' => 'country_id']);
     }
 
     /**


### PR DESCRIPTION
correccion para actualizar/insertar un evento, el primer error pedia que el dato de pais debe ser un valor entero( se cambio el tipo de valor indicado en las rules de base/event) y el segundo error era que registros ya realizados les mostraba el codigo alfa2 en vez del nombre del pais correspondiente(se agrego en el metodo getCountryName que antes de devolver el valor consultara el nombre del pais corespondiente al alfa2 y retornar el nombre del pais)