### PR TITLE
Attendance renombramientos

### DIFF
--- a/models/Attendance.php
+++ b/models/Attendance.php
@@ -31,9 +31,9 @@ class Attendance extends base\Attendance
 
     public function save($runValidation = true, $attributeNames = null)
     {
-        $org = Organization::find()->where(['id'=>(int)$this->org_id])->one();
+        $org = Organization::find()->where(['id'=>(int)$this->organization_id])->one();
 
-        if (!$org && $this->org_name && !$this->org_id) {
+        if (!$org && $this->org_name && !$this->organization_id) {
             $org = Organization::find()->where(['name' => $this->org_name])->one();
             if (!$org) {
                 $org = new Organization;
@@ -55,7 +55,7 @@ class Attendance extends base\Attendance
         try {
             if ($org && $org->isNewRecord) {
                 if ($return &= $org->save())
-                    $this->org_id = $org->id;
+                    $this->organization_id = $org->id;
                 else {
                     Ulog::l([$org->errors]);
                     throw new Exception("No se logró guardar el registro de organización");
@@ -95,7 +95,7 @@ class Attendance extends base\Attendance
         $rules = parent::rules();
         return array_merge(
             [
-                [['event_id', 'type_id', 'contact_id', 'org_id'], 'integer'],
+                [['event_id', 'type_id', 'contact_id', 'organization_id'], 'integer'],
                 [['date'], 'safe'],
                 [['document', 'country_id', 'phone_personal'], 'string', 'max' => 45],
                 [['sex'], 'string', 'max' => 1],
@@ -103,7 +103,7 @@ class Attendance extends base\Attendance
             ],
             [
                 [['fullname'], 'required'],
-                [['contact_id', 'org_id', 'org_name', 'document', 'sex', 'country_id', 'community', 'phone_personal', 'event_id', 'type_id'], 'safe'],
+                [['contact_id', 'organization_id', 'org_name', 'document', 'sex', 'country_id', 'community', 'phone_personal', 'event_id', 'type_id'], 'safe'],
             ]
         );
     }
@@ -175,7 +175,7 @@ class Attendance extends base\Attendance
 
     public function getOrg()
     {
-        return $this->hasOne(Organization::className(), ['id' => 'org_id']);
+        return $this->hasOne(Organization::className(), ['id' => 'organization_id']);
     }
 
     public function getType()

--- a/models/base/Attendance.php
+++ b/models/base/Attendance.php
@@ -17,7 +17,7 @@ use yii\db\ActiveQuery;
  * @property string              $sex
  * @property string              $country_id
  * @property string              $community
- * @property int                 $org_id
+ * @property int                 $organization_id
  * @property string              $phone_personal
  * @property int                 $type_id
  *
@@ -40,7 +40,7 @@ abstract class Attendance extends ActiveRecord
     public function rules()
     {
         return [
-            [['event_id', 'contact_id', 'org_id', 'type_id'], 'integer'],
+            [['event_id', 'contact_id', 'organization_id', 'type_id'], 'integer'],
             [['document', 'country_id', 'phone_personal'], 'string', 'max' => 45],
             [['sex'], 'string', 'max' => 1],
             [['community'], 'string', 'max' => 255],
@@ -62,7 +62,7 @@ abstract class Attendance extends ActiveRecord
             'sex' => 'Sex',
             'country_id' => 'Country',
             'community' => 'Community',
-            'org_id' => 'Org ID',
+            'organization_id' => 'Org ID',
             'phone_personal' => 'Phone Personal',
             'type_id' => 'Type ID',
         ];


### PR DESCRIPTION
Debido al cambio sugerido en la bd para renombrar org_id en la tabla de attendance se tuvo que renombrar en los modelos de attendace para evitar problemas de insercion y actualizacion