### PR TITLE
Problemas al crear un evento

### DIFF
--- a/models/Attendance.php
+++ b/models/Attendance.php
@@ -145,7 +145,7 @@ class Attendance extends base\Attendance
             if (!$this->community) $this->community = $this->contact->community;
             if (!$this->phone_personal) $this->phone_personal = $this->contact->phone_personal;
             if (!$this->org_name) {
-                $this->org_id = $this->contact->organization_id;
+                $this->organization_id = $this->contact->organization_id;
                 $this->org_name = $this->contact->organizationName;
             }
         }


### PR DESCRIPTION
Al crear o actualizar un evento y relacionar participantes a el evento , event ocupa de attendance para indicar los contact que asistiran y faltaba renombrar org_id x organization_id en el metodo que afterfind