### PR TITLE
Guardado de datos al importar sin vincular organizacion

### DIFF
--- a/controllers/ImportController.php
+++ b/controllers/ImportController.php
@@ -243,6 +243,8 @@ class ImportController extends Controller
 
         $this->BeneficiariosPaso2DatosCrearEnBD($resultados, $proyectosRegistrar, $organizacionRegistrar, $paisesRegistrar, $educacionRegistrar);
 
+
+
         $data = [
             'data' => $resultados,
             'errores' => $errores,
@@ -330,7 +332,6 @@ class ImportController extends Controller
                     $eventosCreados[] = $id;
                 }
             }
-
             $transaction->commit();
 
         } catch (Exception $exception) {
@@ -362,7 +363,6 @@ class ImportController extends Controller
                 'project_code' => $model['project_code'],
                 'project_name' => $model['project_name']
             ];
-
         }
 
         $paises = clone $query;
@@ -389,6 +389,7 @@ class ImportController extends Controller
         $organizacion->andFilterWhere(['or', 'organization_id', null]);
         $organizacion->andFilterWhere(['or', 'implementing_organization_id', null]);
         $organizacionRegistrar = [];
+
         foreach ($organizacion->all() as $model) {
             if (is_null($model['implementing_organization_id']))
                 if (!empty($model['implementing_organization_name']))

--- a/models/Event.php
+++ b/models/Event.php
@@ -39,7 +39,7 @@ class Event extends base\Event
         $fechaIngreso = date('Y-m-d');
         $organizacionImplementadora = [];
         $proyectoId = null;
-        $paisNombre = null;
+
         /*Extracción de las variables*/
         extract($data, null);
         $evento = new self();
@@ -70,21 +70,20 @@ class Event extends base\Event
             $evento->structure_id = $id_estructura;
         }
 
-        if (!$organizacionNueva) {
-            $nombreOrg = $organizacionImplementadora['name'];
-            $organization = Organization::find()->where(['name' => $nombreOrg])->one();
-            $id_organization = null;
-            if (is_null($organization)) {
+        if ($organizacionNueva)
+        {
                 $organization = new Organization();
-                $organization->name = $nombreOrg;
+                $organization->name = $organizacionImplementadora['name'];
                 $organization->is_implementer = 1;
 
                 $organization->save();
-                $id_organization = $organization->id;
-            } else {
-                $id_organization = $organization->id;
-            }
-            $evento->organization_id =  $id_organization;
+                 $evento->organization_id = $organization->id;
+        }else
+            {
+            $nombreOrg = $organizacionImplementadora['name'];
+            $organization = Organization::find()->where(['name' => $nombreOrg])->one();
+            $id_organization = null;
+            $evento->organization_id =  $organization->id;
         }
 
         $detallesValidos = true;

--- a/models/Event.php
+++ b/models/Event.php
@@ -39,6 +39,7 @@ class Event extends base\Event
         $fechaIngreso = date('Y-m-d');
         $organizacionImplementadora = [];
         $proyectoId = null;
+        $paisNombre = null;
 
         /*Extracción de las variables*/
         extract($data, null);

--- a/models/base/Organization.php
+++ b/models/base/Organization.php
@@ -91,7 +91,7 @@ abstract class Organization extends ActiveRecord
      */
     public function getCountry0()
     {
-        return $this->hasOne(\app\models\DataList::className(), ['id' => 'country_id']);
+        return $this->hasOne(\app\models\Country::className(), ['id' => 'country_id']);
     }
 
     /**


### PR DESCRIPTION
Se resolvió error Guardando registros vinculando o no Organizacion
Se modificó archivo models/Event.php metodo CreateFromImport.

Anteriormente se producia un error en este archivo cuando no se vinculaban las 
organizaciones. El error ocurria cuando se intentava guardar un evento el campo organization_id
de esta tabla daba error debido a que este campo es un foreigh key de la tabla organization id
como en la condicion  if (!$organizacionNueva) no se cumplia el campo $evento->structure_id = $id_estructura;
nunca se seteaba.
