### PR TITLE
fix busqueda por nombre, agregacion de upper en campo nombre

### DIFF
--- a/controllers/OptController.php
+++ b/controllers/OptController.php
@@ -62,7 +62,7 @@ class OptController extends Controller
 
         $name2 = preg_replace('/\s+/', " ", TRIM($name));
         if ($name2)
-            $query->andWhere("REGEXP_REPLACE(TRIM(sql_contact.name), '( ){2,}', ' ') = '".$name2."'");
+            $query->andWhere("UPPER(REGEXP_REPLACE(TRIM(sql_contact.name), '( ){2,}', ' ')) = UPPER('".$name2."')");
 
         $query->andWhere("NOT TRIM(sql_contact.name) = ''");
 


### PR DESCRIPTION
En la opción de fucionar al importar datos de excel, no se encontraba coincidencia de datos al buscar registro para fusionar. Debido a diferencia de cadena (mayuscula y menuscula).

Se modificó archivo controller/OptController.php método namesQuery
Se agregó en filtro un upper campos sql_contact.name y $name2

 