### PR TITLE
excluyendo db jango en el gitignore e incluyendo dbdjango.sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ phpunit.phar
 tests/_output/*
 tests/_support/_generated
 config/db.php
+config/dbDjango.php
 import/*
 
 # Translations

--- a/config/dbDjango.sample.postgres.php
+++ b/config/dbDjango.sample.postgres.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'class' => 'yii\db\Connection',
+    'dsn' => 'pgsql:host=127.0.0.1;port=5432;dbname=hummus',
+    'username' => 'postgres',
+    'password' => 'root',
+    'charset' => 'utf8',
+    'enableSchemaCache' => true,
+    'schemaCacheDuration' => 3600,
+    'schemaCache' => 'cache',
+];


### PR DESCRIPTION
Se excluye en gitignore archivo de configuración de coneccion a la base de datos django
y se incluye archivo dbDjango.sample.postgres.php 