### PR TITLE
agregando info secret de archivo web.php a archivo secrets.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tests/_output/*
 tests/_support/_generated
 config/db.php
 config/dbDjango.php
+config/secrets.php
 import/*
 
 # Translations

--- a/config/web.php
+++ b/config/web.php
@@ -1,6 +1,7 @@
 <?php
 
 $params = require(__DIR__ . '/params.php');
+$configPrivate = require(__DIR__ . '/secrets.php');
 
 $config = [
     'id' => 'basic',
@@ -76,7 +77,7 @@ $config = [
         ],
         'request' => [
             // !!! insert a secret key in the following (if it is empty) - this is required by cookie validation
-            'cookieValidationKey' => '3Lmk$al1.11651ab4#!¿',
+            'cookieValidationKey' => $configPrivate['request']['validationKey'],
             'parsers' => [
                 'application/json' => 'yii\web\JsonParser',
             ],
@@ -166,7 +167,7 @@ if (YII_ENV_DEV) {
     $config['modules']['debug'] = [
         'class' => 'yii\debug\Module',
         // uncomment the following to add your IP if you are not connecting from localhost.
-        'allowedIPs' => ['127.0.0.1', '::1'],
+        'allowedIPs' => $configPrivate['allowedIPs']['IPs'],
     ];
 
     $config['bootstrap'][] = 'gii';


### PR DESCRIPTION
Los datos que no se deseen mostrar en el archivo web.php se pueden agregar en secrets.php,
para luego ser accedidos como variables desde web.php
 la estructura de secrets.php es:

return [
    'Nombre_Modulo' => ['clave1' => 'valor1',],
    'Nombre_Modulo2' => ['clave2' => [valor2],],
]

