### PR TITLE
eliminando consulta hacia la tb data_list para obtener los alfa2 de c…

### DIFF
--- a/models/AuthUser.php
+++ b/models/AuthUser.php
@@ -194,17 +194,10 @@ class AuthUser extends BaseUser implements IdentityInterface
         if (!is_array($paises))
             $paises = [];
 
-        $query = (new Query());
-        $query->select([
-            "value",
-        ])->from('data_list')
-            ->where(['in', 'id', $paises]);
-        $paisesCode = $query->column();
-
         $queryContact = (new Query());
         $queryContact->select('contact_id')
             ->from('sql_full_report_project_contact')
-            ->orWhere(['in', 'contact_country_code', $paisesCode])
+            ->orWhere(['in', 'contact_country_code', $paises])
             ->orWhere(['in', 'project_id', $proyectos])
             ->andWhere('contact_id is not null')
             ->groupBy('contact_id');


### PR DESCRIPTION
antes para obtener los alfa2 de los paises que son asignados un usuario se consultaba a data list , ahora que el sistema solo consume de country por lo tanto no es necesario realizar esa consulta ya que se almacena los alfa2 de los paises guardados en la tb auth_user_yii