### PR TITLE
Asignacion de  idioma de forma automatica al iniciar session

### DIFF
--- a/components/LanguageSelector.php
+++ b/components/LanguageSelector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace app\components;
+use yii\base\BootstrapInterface;
+
+class LanguageSelector implements BootstrapInterface
+{
+    public $supportedLanguages = [];
+
+    public function bootstrap($app)
+    {
+        $dataUserLogin = \Yii::$app->user->identity;
+
+        if(isset($dataUserLogin))
+            if(in_array($dataUserLogin->language, $this->supportedLanguages))
+                \Yii::$app->language = $dataUserLogin->language;
+    }
+}

--- a/config/web.php
+++ b/config/web.php
@@ -6,7 +6,7 @@ $configPrivate = require(__DIR__ . '/secrets.php');
 $config = [
     'id' => 'basic',
     'basePath' => dirname(__DIR__),
-    'bootstrap' => ['log'],
+    'bootstrap' => ['log','languageSelector',],
     'name' => 'Monitoreo',
     'charset' => 'utf-8',
     'language' => 'en',
@@ -60,6 +60,10 @@ $config = [
     'components' => [
         'assetManager' => [
             'appendTimestamp' => true,
+        ],
+        'languageSelector' => [
+            'class' => 'app\components\LanguageSelector',
+            'supportedLanguages' => ['en','fr','es'],
         ],
 
         'authManager' => [

--- a/models/base/AuthUser.php
+++ b/models/base/AuthUser.php
@@ -23,6 +23,7 @@ use app\components\ActiveRecord;
  * @property string $access_token
  * @property array  $countries
  * @property array  $projects
+ * @property string  $language
  */
 abstract class AuthUser extends ActiveRecord
 {
@@ -43,7 +44,7 @@ abstract class AuthUser extends ActiveRecord
             [['password', 'username', 'first_name', 'is_staff', 'is_active', 'date_joined'], 'required'],
             [['last_login', 'date_joined', 'countries', 'projects'], 'safe'],
             [['is_superuser', 'is_staff', 'is_active'], 'boolean'],
-            [['access_token'], 'string'],
+            [['access_token','language'], 'string'],
             [['password'], 'string', 'max' => 128],
             [['username', 'first_name', 'last_name'], 'string', 'max' => 30],
             [['email'], 'string', 'max' => 254],
@@ -70,6 +71,7 @@ abstract class AuthUser extends ActiveRecord
             'access_token' => Yii::t('app', 'Access Token'),
             'countries' => Yii::t('app', 'Countries'),
             'projects' => Yii::t('app', 'Projects'),
+            'language' => Yii::t('app', 'Language'),
         ];
     }
 }


### PR DESCRIPTION
Asignación de  idioma de forma automatica al iniciar session en sistema

Se agregó archivo 
components/LanguageSelector.php

El cual obtiene los datos de session del usuario logueado,
y extrae el idioma asignado a ese usuario en la tabla 
auth_user_yii en el campo "language"
en caso de ser un idioma soportado por el sistema
se asigna. 

en el archivo config/web.php se realizo la configuracion de este archivo (LanguageSelector.php)
y el AuthUser.php se agrego el nuevo campo de la tabla auth_user_yii

   modified files:   
        modified:   config/web.php
        modified:   models/base/AuthUser.php